### PR TITLE
Diagnosis and fix for missing schedtool

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,13 @@ Get ananicy output with journalctl:
 ```
 $ journalctl -efu ananicy.service
 ```
+
+### Missing `schedtool`
+If you see this error in the output
+```
+Jan 24 09:44:18 tony-dev ananicy[13783]: ERRO: Missing schedtool! Abort!
+```
+Fix it in Ubuntu with
+```
+sudo apt install schedtool
+```


### PR DESCRIPTION
Spotted `ERRO: Missing schedtool! Abort!` in the log output.

Documentation update with diagnosis and fix
