### PR TITLE
Do not print IONICE/IOCLASS warning for bfq-mq

### DIFF
--- a/ananicy
+++ b/ananicy
@@ -264,7 +264,7 @@ check_schedulers(){
         [[ "$disk_name" =~ (loop|ram|sr) ]] && continue
         scheduler_path="$disk_path/queue/scheduler"
         [ ! -f $scheduler_path ] && continue
-        grep -q '\[cfq\]\|\[bfq\]' $scheduler_path || \
+        grep -q '\[cfq\]\|\[bfq\]\|\[bfq-mq\]' $scheduler_path || \
             WARN "Disk $disk_name not used cfq/bfq scheduler IOCLASS/IONICE will not work on it!"
     done
 }


### PR DESCRIPTION
bfq-mq can support them:
CONFIG_MQ_IOSCHED_BFQ=y
CONFIG_MQ_BFQ_GROUP_IOSCHED=y