### PR TITLE
Try to fix meld

### DIFF
--- a/ananicy.d/00-default/meld.rules
+++ b/ananicy.d/00-default/meld.rules
@@ -1,2 +1,2 @@
 # http://meldmerge.org
-NAME=meld TYPE=BG_CPUIO
+NAME='/meld' TYPE=BG_CPUIO


### PR DESCRIPTION
The original pattern (just "meld") matched to a string in the argument vector of a process 
```
28423 /usr/lib/xfce4/panel/wrapper-1.0 /usr/lib/xfce4/panel/plugins/libactions.so 2 176160816 actions Aktionsknöpfe Abmelden, sperren oder andere Systemaktionen
```

(meld is in Abmelden).
This attempts to fix this or at least triage it. I think Ananicy needs a much better way to match processes than just greping for a fixed string in the argument vector.