### PR TITLE
Add SuccessExitStatus=143 to ananicy.service

### DIFF
--- a/ananicy.service
+++ b/ananicy.service
@@ -7,6 +7,7 @@ Type=notify
 ExecStart=/usr/bin/ananicy start
 ExecReload=/usr/bin/ananicy reload
 Nice=19
+SuccessExitStatus=143
 OOMScoreAdjust=-999
 Restart=always
 CPUAccounting=true


### PR DESCRIPTION
If ananicy is stopped using `systemctl stop ananicy.service`, it logs the following messages:
```
Dez 21 18:26:56 thermi-pc.thermicorp.lan systemd[1]: Stopping Ananicy - ANother Auto NICe daemon...       
Dez 21 18:26:56 thermi-pc.thermicorp.lan systemd[1]: ananicy.service: Main process exited, code=exited, status=143/n/a                                                                                                                                        Dez 21 18:26:56 thermi-pc.thermicorp.lan systemd[1]: ananicy.service: Failed with result 'exit-code'.    
Dez 21 18:26:56 thermi-pc.thermicorp.lan systemd[1]: Stopped Ananicy - ANother Auto NICe daemon.     
```

The commit in this branch silences the center two messages.