### PR TITLE
Thunderbird

### DIFF
--- a/ananicy.d/00-default/thunderbird.rules
+++ b/ananicy.d/00-default/thunderbird.rules
@@ -1,2 +1,2 @@
 # https://www.mozilla.org/en-US/thunderbird/
-NAME=thunderbird TYPE=LowLatency_RT PGREP_ARGS='-wx'
+NAME=thunderbird TYPE=CHAT PGREP_ARGS='-wx'

--- a/ananicy.d/00-default/thunderbird.rules
+++ b/ananicy.d/00-default/thunderbird.rules
@@ -1,2 +1,2 @@
 # https://www.mozilla.org/en-US/thunderbird/
-NAME=thunderbird TYPE=BG_CPUIO
+NAME=thunderbird TYPE=LowLatency_RT PGREP_ARGS='-wx'


### PR DESCRIPTION
Fix the rule for thunderbird and give it a much higher priority by changing the type to LowLatency_RT.