### PR TITLE
Update gcc.rules

### DIFF
--- a/ananicy.d/00-default/gcc.rules
+++ b/ananicy.d/00-default/gcc.rules
@@ -1,1 +1,4 @@
+# cc1 and cc1plus high CPU usage compilers invoked by GCC
 { "name": "gcc", "type": "BG_CPUIO" }
+{ "name": "cc1", "type": "BG_CPUIO" }
+{ "name": "cc1plus", "type": "BG_CPUIO" }


### PR DESCRIPTION
GCC the driver program (gcc) calls the compiler (cc1, cc1plus). Should include compilers to rules file