### PR TITLE
Remove kwin_wayland rule in _kde.rules

### DIFF
--- a/ananicy.d/00-default/_kde.rules
+++ b/ananicy.d/00-default/_kde.rules
@@ -5,7 +5,6 @@
 
 { "name": "krunner",      "type": "LowLatency_RT" }
 { "name": "kwin_x11",     "type": "LowLatency_RT" }
-{ "name": "kwin_wayland", "type": "LowLatency_RT" }
 { "name": "plasmashell",  "nice": -1 }
 
 { "name": "kdeconnectd",  "type": "BG_CPUIO" }


### PR DESCRIPTION
With reference from https://blog.martin-graesslin.com/blog/2017/09/kwinwayland-goes-real-time/ , We can remove the rule as it may interfere with the scheduler policy adjustment thus impacting desktop interactivity.

"KWin gained a new optional dependency on libcap and on installation sets the capability CAP_SYS_NICE on the kwin_wayland binary. On startup kwin_wayland adjusts the scheduler policy to request SCHED_FIFO and drops the capability again before doing anything else."