### PR TITLE
Add Plex Media Player and WebQT backend rules.

### DIFF
--- a/ananicy.d/00-default/plex.rules
+++ b/ananicy.d/00-default/plex.rules
@@ -1,2 +1,2 @@
-# Video player: http://www.videolan.org/vlc/index.html
+# Video player: https://github.com/plexinc/plex-media-player
 { "name": "plexmediaplayer", "type": "Player-Video" }

--- a/ananicy.d/00-default/plex.rules
+++ b/ananicy.d/00-default/plex.rules
@@ -1,0 +1,2 @@
+# Video player: http://www.videolan.org/vlc/index.html
+{ "name": "plexmediaplayer", "type": "Player-Video" }

--- a/ananicy.d/00-default/qtwebengine.rules
+++ b/ananicy.d/00-default/qtwebengine.rules
@@ -1,2 +1,2 @@
-# Video player: http://www.videolan.org/vlc/index.html
+# Video player: https://doc.qt.io/qt-5.11/qtwebengine-index.html
 { "name": "QtWebEngineProcess", "type": "Player-Video" }

--- a/ananicy.d/00-default/qtwebengine.rules
+++ b/ananicy.d/00-default/qtwebengine.rules
@@ -1,0 +1,2 @@
+# Video player: http://www.videolan.org/vlc/index.html
+{ "name": "QtWebEngineProcess", "type": "Player-Video" }


### PR DESCRIPTION
Honestly I don't know if webqt must be set on "video player" or "web browser", since it's mainly used by Plex as some kind of backend. Seeing that webqtengine uses more CPU and RAM than the plex app I set it to video player.