### PR TITLE
A rule for linphone

### DIFF
--- a/ananicy.d/00-default/linphone.rules
+++ b/ananicy.d/00-default/linphone.rules
@@ -1,0 +1,2 @@
+# rule for linphone, a SIP client. http://www.linphone.org/technical-corner/linphone/overview
+{ "name" : "linphon", "type" : "LowLatency_RT", "nice" : -15, "ioclass" : "realtime" }


### PR DESCRIPTION
Linphone is a SIP client. I used nice -15 to make sure it has priority over other interactive applications like Thunderbird. If it doesn't get enough processing time, the sip calls will be spotty.