### PR TITLE
Add realtime io class rules for desktop rendering/usage related processes

### DIFF
--- a/ananicy.d/00-default/lightdm.rules
+++ b/ananicy.d/00-default/lightdm.rules
@@ -1,0 +1,3 @@
+## Rule for lightdm display manager, starts the Xorg server
+
+{ "name" : "lightdm", "ioclass" : "realtime", "ionice" : 4, "oom_score_adj": -1000 }

--- a/ananicy.d/00-default/xfce4.rules
+++ b/ananicy.d/00-default/xfce4.rules
@@ -1,6 +1,6 @@
-{ "name": "xfwm4",           "type": "LowLatency_RT" }
-{ "name": "xfsettingsd",     "type": "LowLatency_RT" }
-{ "name": "xfce4-session",   "type": "LowLatency_RT" }
-{ "name": "xfconfd",         "type": "LowLatency_RT" }
-{ "name": "xfce4-appfinder", "type": "LowLatency_RT" }
-{ "name": "xfce4-notifyd",   "type": "LowLatency_RT" }
+{ "name": "xfwm4",           "type": "LowLatency_RT", "ioclass" : "realtime", "ionice" : 4 }
+{ "name": "xfsettingsd",     "type": "LowLatency_RT", "ioclass" : "realtime", "ionice" : 4 }
+{ "name": "xfce4-session",   "type": "LowLatency_RT", "ioclass" : "realtime", "ionice" : 4 }
+{ "name": "xfconfd",         "type": "LowLatency_RT", "ioclass" : "realtime", "ionice" : 4 }
+{ "name": "xfce4-appfinder", "type": "LowLatency_RT", "ioclass" : "realtime", "ionice" : 4 }
+{ "name": "xfce4-notifyd",   "type": "LowLatency_RT", "ioclass" : "realtime", "ionice" : 4 }

--- a/ananicy.d/00-default/xorg.rules
+++ b/ananicy.d/00-default/xorg.rules
@@ -1,0 +1,3 @@
+## Rule for Xorg server, runs the graphical desktop.
+
+{ "name" : "Xorg", "ioclass" : "realtime", "ionice" : 1, "oom_score_adj": -1000 }


### PR DESCRIPTION
Turns out that although Xorg does not access any disks when it runs and renders the desktop, the IO class still has influence over when it is scheduled to update the rendered frames on the screen. By setting the IO class to realtime and giving it a high priority, it is ensured that xorg has enough CPU time available to update the screen, even when the system experiences a high IO load.
Also, lightdm, which is a login manager, is given a high realtime priority to allow users to login to the graphical desktop.
XFCE4 desktop environment related processes are also given the realtime IO class with a high priority to ensure using these applications is sufficiently quick.

Let me know what you think.

It'd be also possible to use the deadline CPU scheduling class, but that's not supported by schedutil, but by chrt. chrt in turn doesn't support the SCHED_ISO class. It's possible to write code to switch around the utilities based on the scheduling class or go to kernel API calls directly.