### PR TITLE
Add qbittorrent-nox, vscode and use LowLatencty_RT for ffmpeg

### DIFF
--- a/ananicy.d/00-default/ffmpeg.rules
+++ b/ananicy.d/00-default/ffmpeg.rules
@@ -1,2 +1,2 @@
 # ffmpeg - audio and video converter: https://www.ffmpeg.org/
-{ "name": "ffmpeg", "type": "Heavy_CPU" }
+{ "name": "ffmpeg", "type": "LowLatency_RT" }

--- a/ananicy.d/00-default/okular.rules
+++ b/ananicy.d/00-default/okular.rules
@@ -1,0 +1,2 @@
+# Okular PDF KDE reader
+{ "name": "okular", "type": "Doc-View" }

--- a/ananicy.d/00-default/qBittorrent.rules
+++ b/ananicy.d/00-default/qBittorrent.rules
@@ -1,2 +1,3 @@
 # QT bittorrent client
 { "name": "qbittorrent", "type": "BG_CPUIO" }
+{ "name": "qbittorrent-nox", "type": "BG_CPUIO" }

--- a/ananicy.d/00-default/syncthing.rules
+++ b/ananicy.d/00-default/syncthing.rules
@@ -1,0 +1,3 @@
+# Syncthing client: https://syncthing.net/
+{ "name": "syncthing", "type": "BG_CPUIO" }
+{ "name": "syncthing-gtk", "type": "BG_CPUIO" }

--- a/ananicy.d/00-default/vscode.rules
+++ b/ananicy.d/00-default/vscode.rules
@@ -1,0 +1,2 @@
+# https://code.visualstudio.com/
+{ "name": "code", "type": "Doc-View" }


### PR DESCRIPTION
Hi @Nefelim4ag,

New rules: qbittorent-nox (see `transmission.rules`, useful as on desktop webui may be preferable) and vscode (Visual Studio Code).

Choosing `LowLatencty_RT` for ffmpeg may be required, as this is used in browsers/players nowadays to play video/audio and this won't lead to lag or frame dropping.
The same rules could be applied to `mpv` as well, a lot of players choose this backend to process media.

Please let me know what you think. :)

Thanks.