### PR TITLE
Fix the Discord rule to use the correct case in the name

### DIFF
--- a/ananicy.d/00-default/discord.rules
+++ b/ananicy.d/00-default/discord.rules
@@ -1,2 +1,2 @@
 # Discord: https://discordapp.com/
-{ "name": "discord", "type": "LowLatency_RT" }
+{ "name": "Discord", "type": "LowLatency_RT" }


### PR DESCRIPTION
Rules are case sensitive & the Discord binary is named "Discord" w/ a capital D.