### PR TITLE
added cc1plus and xz

### DIFF
--- a/ananicy.d/00-default/cc1plus.rules
+++ b/ananicy.d/00-default/cc1plus.rules
@@ -1,0 +1,1 @@
+{ "name": "cc1plus", "type": "BG_CPUIO" }

--- a/ananicy.d/00-default/xz.rules
+++ b/ananicy.d/00-default/xz.rules
@@ -1,0 +1,1 @@
+{ "name": "xz", "type": "BG_CPUIO" }


### PR DESCRIPTION
cc1plus is always active during my aur compiles, I don't see it covered in the other defaults? xz too while "cleaning up" the package