### PR TITLE
rclone.rules

### DIFF
--- a/ananicy.d/00-default/rclone.rules
+++ b/ananicy.d/00-default/rclone.rules
@@ -1,0 +1,1 @@
+{ "name": "rclone", "type": "BG_CPUIO" }

--- a/ananicy.d/00-default/rclone.rules
+++ b/ananicy.d/00-default/rclone.rules
@@ -1,1 +1,2 @@
+#Rclone - rsync for cloud storage
 { "name": "rclone", "type": "BG_CPUIO" }


### PR DESCRIPTION
rclone works on the background, especially when using one of the multiple cache options. It creates a few processes and this rule maintains system responsiveness while not noticeably interfering with normal usage of the mounts (even 4K video streaming). Tested on a Pi4, with --vfs-cache-mode=writes, --dir-cache-time=24h and --cache-dir on external USB 3 HDD, 100Mbps fiber upload.

io priority rules should not be necessary. Maybe with gigabit upload connections!