### PR TITLE
Add rules for ark, dnsmasq, konsole and yay

### DIFF
--- a/ananicy.d/00-default/archlinux.rules
+++ b/ananicy.d/00-default/archlinux.rules
@@ -1,4 +1,5 @@
 # Some rules for Arch Linux specific tools
 
 { "name": "mkinitcpio", "type": "BG_CPUIO" }
+{ "name": "makepkg", "type": "BG_CPUIO" }
 { "name": "pacman", "type": "BG_CPUIO" }

--- a/ananicy.d/00-default/ark.rules
+++ b/ananicy.d/00-default/ark.rules
@@ -1,0 +1,2 @@
+# ark KDE archiver
+{"name": "ark", "type": "BG_CPUIO"}

--- a/ananicy.d/00-default/dnsmasq.rules
+++ b/ananicy.d/00-default/dnsmasq.rules
@@ -1,0 +1,2 @@
+# dnsmasq DNS cache system
+{ "name": "dnsmasq", "type": "Doc-View" }

--- a/ananicy.d/00-default/konsole.rules
+++ b/ananicy.d/00-default/konsole.rules
@@ -1,0 +1,2 @@
+# Konsole
+{ "name": "konsole", "type": "Doc-View" }

--- a/ananicy.d/00-default/yay.rules
+++ b/ananicy.d/00-default/yay.rules
@@ -1,0 +1,3 @@
+# yay - Yet another Yogurt 
+
+{ "name": "yay", "type": "BG_CPUIO" }


### PR DESCRIPTION
This PR will add rules for:
- ark
- dnsmasq
- konsole
- yay

It will also add `makepkg` to archlinux rules