### PR TITLE
Include firefox-bin in firefox.rules

### DIFF
--- a/ananicy.d/00-default/firefox.rules
+++ b/ananicy.d/00-default/firefox.rules
@@ -1,5 +1,6 @@
 # https://www.mozilla.org/firefox/
 { "name": "firefox", "type":"Doc-View" }
+{ "name": "firefox-bin", "type":"Doc-View" }
 { "name": "firefox-esr", "type":"Doc-View" }
 # Icecat
 { "name": "icecat", "type":"Doc-View" }


### PR DESCRIPTION
Sometimes, the Firefox process is named `firefox-bin` (for example when using the binaries provided on the official website).