### PR TITLE
Removed un-necessary things and fixed steam bug

### DIFF
--- a/ananicy.d/00-default/_steam.rules
+++ b/ananicy.d/00-default/_steam.rules
@@ -1,6 +1,6 @@
 ################################################################################
 # Rules for Steam and Steam Apps: http://store.steampowered.com
-{ "name": "steam", "type": "BG_CPUIO" }
+#{ "name": "steam", "type": "BG_CPUIO" }
 # Steam integrated web browser
 { "name": "steamwebhelper", "type": "BG_CPUIO" }
 

--- a/ananicy.d/00-default/cc1plus.rules
+++ b/ananicy.d/00-default/cc1plus.rules
@@ -1,1 +1,0 @@
-{ "name": "cc1plus", "type": "BG_CPUIO" }

--- a/ananicy.d/00-default/xz.rules
+++ b/ananicy.d/00-default/xz.rules
@@ -1,1 +1,0 @@
-{ "name": "xz", "type": "BG_CPUIO" }


### PR DESCRIPTION
cc1 is already set to BG_CPU by something else so I presume cc1plus will too
xz is already in _archivers
There is a bug with the steam settings, running any game not defined e.g black mesa makes it inherit the BG_CPU property of steam, I noticed it was running with priority 19, rip