### PR TITLE
Access rules directories in sorted order

### DIFF
--- a/ananicy.py
+++ b/ananicy.py
@@ -506,7 +506,7 @@ class Ananicy:
 
     def find_files(self, path, name_mask):
         files = []
-        entries = os.listdir(path)
+        entries = sorted(os.listdir(path))
         if not entries:
             return files
         for entry_name in entries:


### PR DESCRIPTION
This provides a stable rule parsing order. e.g.
A directoory named `10-overrides` will always be accessed after
`00-default`, rather than in the order the filesystem returns.

Closes #274