### PR TITLE
Add picom (compton fork) to existing compton rules.

### DIFF
--- a/ananicy.d/00-default/compton.rules
+++ b/ananicy.d/00-default/compton.rules
@@ -1,2 +1,4 @@
 # https://github.com/chjj/compton
+# https://github.com/yshui/picom
 { "name": "compton", "type": "LowLatency_RT" }
+{ "name": "picom", "type": "LowLatency_RT" }


### PR DESCRIPTION
Pretty much as it says on the tin - this adds picom to the existing compton rules, since it the same underlying program.

I can create a separate rule just for picom, but wasn't sure that it was really necessary.