### PR TITLE
Switch discord from "LowLatency_RT" to "Chat"

### DIFF
--- a/ananicy.d/00-default/discord.rules
+++ b/ananicy.d/00-default/discord.rules
@@ -1,2 +1,2 @@
 # Discord: https://discordapp.com/
-{ "name": "Discord", "type": "LowLatency_RT" }
+{ "name": "Discord", "type": "Chat" }


### PR DESCRIPTION
A "real-time" priority is normally used for apps like the window manager (which is needed for basic responsiveness).
This gives it a nice value of `-3` instead of `-10`, making sure the system knows that `xorg` and the window manager are more important. 

Changing Discord to "type": "Chat" also makes it more consistent with other chat applications like Slack, Telegram, etc.....