### PR TITLE
Add clang-tidy

### DIFF
--- a/ananicy.d/00-default/clang-tidy.rules
+++ b/ananicy.d/00-default/clang-tidy.rules
@@ -1,0 +1,1 @@
+{ "name": "clang-tidy", "type": "BG_CPUIO" }


### PR DESCRIPTION
Clang-tidy is a static analyser and as such is very CPU and IO intensive. Make it ``BG_CPUIO`` like we do with compilers.