### PR TITLE
makefile: improve specifying destinations & update package.sh to match

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,30 +1,34 @@
-PREFIX ?= /
+PREFIX ?= /usr
+SYSTEMDUNITDIR ?= $(PREFIX)/lib/systemd/system
+BINDIR ?= $(PREFIX)/bin
+LIBDIR ?= $(PREFIX)/lib
+SYSCONFDIR ?= /etc
 
 SRC_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 
 ANANICY_D_R := $(shell find $(SRC_DIR)/ananicy.d -type f -name "*.rules")
-ANANICY_D_R_I := $(patsubst $(SRC_DIR)/%.rules, $(PREFIX)/etc/%.rules, $(ANANICY_D_R))
+ANANICY_D_R_I := $(patsubst $(SRC_DIR)/%.rules, $(SYSCONFDIR)/%.rules, $(ANANICY_D_R))
 
 ANANICY_D_T := $(shell find $(SRC_DIR)/ananicy.d -type f -name "*.types")
-ANANICY_D_T_I := $(patsubst $(SRC_DIR)/%.types, $(PREFIX)/etc/%.types, $(ANANICY_D_T))
+ANANICY_D_T_I := $(patsubst $(SRC_DIR)/%.types, $(SYSCONFDIR)/%.types, $(ANANICY_D_T))
 
 ANANICY_D_G := $(shell find $(SRC_DIR)/ananicy.d -type f -name "*.cgroups")
-ANANICY_D_G_I := $(patsubst $(SRC_DIR)/%.cgroups, $(PREFIX)/etc/%.cgroups, $(ANANICY_D_G))
+ANANICY_D_G_I := $(patsubst $(SRC_DIR)/%.cgroups, $(SYSCONFDIR)/%.cgroups, $(ANANICY_D_G))
 
-A_SERVICE := $(PREFIX)/lib/systemd/system/ananicy.service
-A_CONF := $(PREFIX)/etc/ananicy.d/ananicy.conf
-A_BIN := $(PREFIX)/usr/bin/ananicy
+A_SERVICE := $(LIBDIR)/systemd/system/ananicy.service
+A_CONF := $(SYSCONFDIR)/ananicy.d/ananicy.conf
+A_BIN := $(BINDIR)/ananicy
 
 
 default:  help
 
-$(PREFIX)/etc/%.cgroups: $(SRC_DIR)/%.cgroups
+$(SYSCONFDIR)/%.cgroups: $(SRC_DIR)/%.cgroups
 	install -Dm644 $< $@
 
-$(PREFIX)/etc/%.types: $(SRC_DIR)/%.types
+$(SYSCONFDIR)/%.types: $(SRC_DIR)/%.types
 	install -Dm644 $< $@
 
-$(PREFIX)/etc/%.rules: $(SRC_DIR)/%.rules
+$(SYSCONFDIR)/%.rules: $(SRC_DIR)/%.rules
 	install -Dm644 $< $@
 
 $(A_CONF): $(SRC_DIR)/ananicy.d/ananicy.conf

--- a/package.sh
+++ b/package.sh
@@ -10,12 +10,16 @@ debian_package(){
     VERSION=$(git tag --sort version:refname | tail -n 1)
     [ -z "$VERSION" ] && ERRO "Can't get git tag, VERSION are empty!"
     DEB_NAME="ananicy-${VERSION}_any"
-    
+
     # cleanup after previous installation
     rm "./${DEB_NAME}.deb" && rm -rf "${DEB_NAME}"
-    
+
     mkdir -p "${DEB_NAME}"
-    make install PREFIX="${DEB_NAME}"
+    make install \
+        PREFIX="${DEB_NAME}" \
+        SYSCONFDIR="${DEB_NAME}/etc" \
+        SYSTEMDUNITDIR=/lib/systemd/system
+
     mkdir -p "${DEB_NAME}/DEBIAN/"
     {
         echo "Package: ananicy"


### PR DESCRIPTION
i am packaging Ananicy for nixos and the makefile was installing files in the arch locations which aren't correct for nixos.